### PR TITLE
Changed networking to only initalize on Play

### DIFF
--- a/Assets/Scrabby/Scripts/Interface/MainMenu/MainMenuController.cs
+++ b/Assets/Scrabby/Scripts/Interface/MainMenu/MainMenuController.cs
@@ -6,6 +6,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
+using Network = Scrabby.Networking.Network;
 
 namespace Scrabby.Interface
 {
@@ -84,6 +85,9 @@ namespace Scrabby.Interface
 
             Map.Active = map;
             Robot.Active = robot;
+
+            Network.instance.Init();
+
             SceneManager.LoadScene(map.sceneIndex);
         }
 

--- a/Assets/Scrabby/Scripts/Networking/Network.cs
+++ b/Assets/Scrabby/Scripts/Networking/Network.cs
@@ -23,6 +23,10 @@ namespace Scrabby.Networking
                 new StormConnection()
             };
             
+            // _networks.ForEach(n => n.Init());
+        }
+
+        public void Init() {
             _networks.ForEach(n => n.Init());
         }
         

--- a/Assets/Scrabby/Scripts/Networking/PyScrabby/PyScrabbyConnection.cs
+++ b/Assets/Scrabby/Scripts/Networking/PyScrabby/PyScrabbyConnection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
@@ -154,6 +154,8 @@ namespace Scrabby.Networking.PyScrabby
         {
             _client?.Close();
             _clientStream?.Close();
+            _thread.Abort();
+            _listener.Stop();
         }
 
         public void Destroy()

--- a/Assets/Scrabby/Scripts/Networking/ROS/RosConnection.cs
+++ b/Assets/Scrabby/Scripts/Networking/ROS/RosConnection.cs
@@ -18,6 +18,8 @@ namespace Scrabby.Networking.ROS
 
         public void Init()
         {
+            _dead = false;
+            
             _socket = new WebSocket("ws://localhost:9090");
             _socket.OnClose += OnClose;
             _socket.OnError += OnError;


### PR DESCRIPTION
This change fixes the issue with the simulator disconnecting all clients after returning to the main menu by re-initalizing all connections on Play.

This also means that the connections are no longer initalized upon the launch of Scrabby, but I think this is a good change. In the future, there could be options in the Settings to turn on/off different networking options (PyScrabby, ROS, etc) to reduce number of threads.